### PR TITLE
Docs: Adicionando template para pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# 📌 Descrição da PR
+Forneça informações sobre as mudanças realizadas nesta PR, destacando de forma breve o objetivo principal da modificação.
+
+## 🔗 Link da task
+[Clique aqui para acessar o card da tarefa](link...)
+
+#### Tasks relacionadas
+- link
+
+## 📝 Tipo de Mudança
+- [ ] Novo endpoint
+- [ ] Alteração em endpoint existente
+- [ ] Correção de bug
+- [ ] Refatoração
+- [ ] Alteração de configuração (build, CI/CD, etc.)
+- [ ] Alteração crítica (breaking change)
+
+## ⚙️ Como foi testado?
+- Corpo de resposta validado
+- Códigos de status HTTP verificados
+- Cenários de erro tratados e testados
+
+# ✅ Checklist Antes do Merge
+- [ ] Testes passando no ambiente local e no CI
+- [ ] Sem credenciais ou dados sensíveis
+- [ ] Tratamento de erros padronizado
+- [ ] Logs e monitoramento adequados adicionados (se necessário)
+- [ ] Documentações necessária atualizadas
+
+


### PR DESCRIPTION
Foi criada a pasta `.github` contendo o arquivo `pull_request_template.md`, que define o template padrão para as Pull Requests deste repositório.
O objetivo é padronizar as descrições das PRs, garantindo maior clareza e qualidade.